### PR TITLE
Replace title with name

### DIFF
--- a/torrents/libgen.py
+++ b/torrents/libgen.py
@@ -82,7 +82,7 @@ class Libgen:
                     my_dict['data'].append({
                         'id': id,
                         'authors': authors,
-                        'title': name,
+                        'name': name,
                         'publisher': publisher,
                         'year': year,
                         'pages': pages,


### PR DESCRIPTION
Every other sites returns `name` except libgen which return `title` making it irregular.